### PR TITLE
Create Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,15 @@
+# Dockerfile to build the TrackR-Web-Bluetooth software for testing
+# This is a proof of concept that:
+# a) detects and pairs with a TrackR Pixel if it's nearby
+# b) triggers its sound when the web page's button is pushed
+
+FROM tiangolo/uwsgi-nginx-flask:python3.8-alpine
+
+WORKDIR /app
+COPY . /app
+
+RUN pip install flask
+
+# ENTRYPOINT [ "python"]
+CMD [ "python", "app.py"]
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -10,6 +10,5 @@ COPY . /app
 
 RUN pip install flask
 
-# ENTRYPOINT [ "python"]
 CMD [ "python", "app.py"]
 

--- a/README.md
+++ b/README.md
@@ -35,6 +35,7 @@ To run the Docker container:
 
 ``` 
 docker run  -p 5001:5001 trackr
+# Enter Ctl-C to stop the Docker instance and clean up
 ```
 
 To test the binary (which by default listens on port 5001), go to [http://127.0.0.1:5001](http://127.0.0.1:5001)

--- a/README.md
+++ b/README.md
@@ -11,9 +11,33 @@ The goal of this project is to reverse engineer and open source the TrackR devic
 
 ## Instructions
 The proof-of-concept uses a Python Flask server to host a single HTML/JS page that one can use to connect to and trigger a TrackR device. To set it up, you will need to:
+
 1. Install Python 3.x
 2. Install Flask (`pip install flask`)
 3. Clone the repo
-4. Run app.py (CD to the folder containing main.py and run `python app.py`)
-5. Go to http://127.0.0.1:5000/ in a browser that supports the Web Bluetooth API (such as Chrome).
+4. Run app.py (`cd` to the folder containing app.py and run `python app.py`)
+5. Go to http://127.0.0.1:5001/ in a browser that supports the Web Bluetooth API (such as Chrome).
 6. Follow the directions on the page to trigger your TrackR device
+
+## Docker instructions
+
+The Dockerfile in this repo builds a Docker container that runs the program
+without any concerns about dependencies on the host system.
+(No Python/Flask/pip version worries; no `pyenv` required...)
+
+To build the Docker container:
+
+```
+docker build -t findtrackr .
+```
+
+To run the Docker container:
+
+``` 
+docker run  -p 5001:5001 trackr
+```
+
+To test the binary (which by default listens on port 5001), go to [http://127.0.0.1:5001](http://127.0.0.1:5001)
+
+Note: As of mid-2022, only Chrome and Edge support the Web Bluetooth API.
+This program will not work with current Firefox or Safari browsers.

--- a/app.py
+++ b/app.py
@@ -9,4 +9,4 @@ def trackr_trigger_page():
 
 
 if __name__ == '__main__':
-    app.run()
+    app.run(host ='0.0.0.0', port = 5001, debug = True)

--- a/templates/home.html
+++ b/templates/home.html
@@ -8,9 +8,8 @@
 </head>
 <body>
     <style>
-        div {padding: 10px}
+        body {padding: 10px}
     </style>
-    <div>
 <h1>TrackR Pixel Proof of Concept</h1>
 <p>
     This is a proof of concept that lets you trigger a TrackR from a web browser. It only works in browsers that
@@ -42,7 +41,6 @@
 <br>
 <br>
 <i>*You might not need to follow the battery removal and reinsertion steps, and the TrackR might trigger without you needing to press the Pair/Trigger button a second time.</i>
-</div>
 </body>
 
 <script>

--- a/templates/home.html
+++ b/templates/home.html
@@ -4,8 +4,14 @@
     <script src="{{ url_for('static', filename='trackr.js') }}"></script>
     <meta charset="UTF-8">
     <title>TrackR Web Bluetooth Proof of Concept</title>
+    <link rel="stylesheet" href="https://unpkg.com/mvp.css">
 </head>
 <body>
+    <style>
+        div {padding: 10px}
+    </style>
+    <div>
+<h1>TrackR Pixel Proof of Concept</h1>
 <p>
     This is a proof of concept that lets you trigger a TrackR from a web browser. It only works in browsers that
     implement the Web Bluetooth API. If you find that the Bluetooth features are not working, make sure you have it
@@ -36,6 +42,7 @@
 <br>
 <br>
 <i>*You might not need to follow the battery removal and reinsertion steps, and the TrackR might trigger without you needing to press the Pair/Trigger button a second time.</i>
+</div>
 </body>
 
 <script>


### PR DESCRIPTION
I like to run programs in Docker, specifically to avoid the concerns about version numbers of software that I don't use regularly.

The Dockerfile builds a container that uses Python 3.8 and Flask to run the Web Bluetooth API application. In so doing, I needed to change the port from 5000 to 5001 (I'm not sure why - but it made Docker work...) 

I updated the README to show how to build and run the Docker container. Finally, I added in MVP.css to "pretty up" the web page.

Thanks for this tool! Now I have another toy to play with!